### PR TITLE
Make it possible to add padding props to accept both arrays and strings

### DIFF
--- a/src/components/~reusables/atoms/Container.js
+++ b/src/components/~reusables/atoms/Container.js
@@ -6,8 +6,7 @@ export const Container = styled.div`
   ${props => (props.vCenter ? `justify-content: center;` : null)}
   ${props => (props.column ? `flex-direction: column;` : null)}
   ${props => (props.hCenter ? `align-items: center;` : null)}
-  ${props => (Array.isArray(props.padding) ? `padding: ${props.padding[0]} ${props.padding[1]};` : null)}
-  ${props => (Array.isArray(props.padding) === false ? `padding: ${props.padding};` : null)}
+  ${props => (props.padding && Array.isArray(props.padding) ? `padding: ${props.padding.join(' ')};` : props.padding && !Array.isArray(props.padding) ? `padding: ${props.padding};` : '')}
   ${props => (props.width ? `width: ${props.width};` : null)}
   ${props => (props.bgColor ? `background-color: ${props.bgColor};` : null)}
 `;


### PR DESCRIPTION
# What would this PR do?
 - It makes padding props passing very flexible in that it allows for the padding to be passed as either an `array` or a `string`
Example ```<Container padding={['20px', '30px']} />```
                ```<Container padding="20px" />```